### PR TITLE
Switch to main branch for fractal-helper-tasks

### DIFF
--- a/.github/workflows/external-packages.yml
+++ b/.github/workflows/external-packages.yml
@@ -37,7 +37,7 @@ jobs:
 
           - package: fractal-helper-tasks
             github_repo: fractal-analytics-platform/fractal-helper-tasks
-            github_branch: use-fractal-task-tools
+            github_branch: main
             cmd_install: 'python -m pip install -e .'
 
           # - package: APx_fractal_task_collection


### PR DESCRIPTION
This will likely fail atm, because fractal-helper-tasks in its current main is used with the `--fractal-server-2-13`. Once we deploy 2.14, I'll make a new helper task release that should then pass this CI.

(I don't think it's necessary to expose the 2.13 option in this CI for now. If we add options like this later again, we may want to expose the options for packages to provide their own extra options for the manifest check)